### PR TITLE
Add some codes in resetEntityAttributes() in VolatileCodeEnabled_1_7_Spi...

### DIFF
--- a/src/com/nisovin/magicspells/volatilecode/VolatileCodeEnabled_1_7_Spigot.java
+++ b/src/com/nisovin/magicspells/volatilecode/VolatileCodeEnabled_1_7_Spigot.java
@@ -641,6 +641,31 @@ public class VolatileCodeEnabled_1_7_Spigot implements VolatileCodeHandle {
 
 	@Override
 	public void resetEntityAttributes(LivingEntity entity) {
+		try {
+			EntityLiving e = ((CraftLivingEntity)entity).getHandle();
+			Field field = EntityLiving.class.getDeclaredField("d");
+			field.setAccessible(true);
+			field.set(e, null);
+			e.getAttributeMap();
+			Method method = null;
+			Class<?> clazz = e.getClass();
+			while (clazz != null) {
+				try {
+					method = clazz.getDeclaredMethod("aD");
+					break;
+				} catch (NoSuchMethodException e1) {
+				    clazz = clazz.getSuperclass();
+				}
+			}
+			if (method != null) {
+				method.setAccessible(true);
+				method.invoke(e);
+			} else {
+				throw new Exception("No method aD found on " + e.getClass().getName());
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
 	}
 
 }


### PR DESCRIPTION
...got.java

I changed getDeclaredField("c") to getDeclaredField("d").
It works fine.
I changed getDeclaredMethod("aW") to getDeclaredMethod("aD").
It works fine, too.
I tested this in my 1.7 server, this method works nice!
I think you can use this into your source.

How to I know this:
I decompiled 1.7 bukkit and 1.8 bukkit.
and I find 2 words in EntityLiving.class
- 1.7:
    protected AttributeMapBase d;
    protected boolean aD;
- 1.8:
    protected AttributeMapBase c;
    protected boolean aW;

so I think I can fix this.

Sorry for my English. (I'm not American.)