### PR TITLE
Player disguise fix

### DIFF
--- a/src/com/nisovin/magicspells/spells/targeted/DisguiseSpell.java
+++ b/src/com/nisovin/magicspells/spells/targeted/DisguiseSpell.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -339,7 +340,7 @@ public class DisguiseSpell extends TargetedSpell implements TargetedEntitySpell 
 	private void disguise(Player player) {
 		String nameplate = nameplateText;
 		if (showPlayerName) nameplate = player.getDisplayName();
-		PlayerDisguiseData playerDisguiseData = (entityType == EntityType.PLAYER ? new PlayerDisguiseData(uuid, skin, skinSig) : null);
+		PlayerDisguiseData playerDisguiseData = entityType == EntityType.PLAYER ? new PlayerDisguiseData((uuid.isEmpty() ? UUID.randomUUID().toString() : uuid), skin, skinSig) : null;
 		Disguise disguise = new Disguise(player, entityType, nameplate, playerDisguiseData, alwaysShowNameplate, ridingBoat, flag, var1, var2, var3, duration, this);
 		manager.addDisguise(player, disguise);
 		disguised.put(player.getName().toLowerCase(), disguise);

--- a/src/com/nisovin/magicspells/spells/targeted/DisguiseSpell.java
+++ b/src/com/nisovin/magicspells/spells/targeted/DisguiseSpell.java
@@ -384,14 +384,14 @@ public class DisguiseSpell extends TargetedSpell implements TargetedEntitySpell 
 	@EventHandler
 	public void onDeath(PlayerDeathEvent event) {
 		if (undisguiseOnDeath && disguised.containsKey(event.getEntity().getName().toLowerCase())) {
-			manager.removeDisguise(event.getEntity(), false);
+			manager.removeDisguise(event.getEntity(), entityType == EntityType.PLAYER);
 		}
 	}
 	
 	@EventHandler
 	public void onQuit(PlayerQuitEvent event) {
 		if (undisguiseOnLogout && disguised.containsKey(event.getPlayer().getName().toLowerCase())) {
-			manager.removeDisguise(event.getPlayer(), false);
+			manager.removeDisguise(event.getPlayer(), entityType == EntityType.PLAYER);
 		}
 	}
 	

--- a/src/com/nisovin/magicspells/util/DisguiseManager.java
+++ b/src/com/nisovin/magicspells/util/DisguiseManager.java
@@ -69,12 +69,13 @@ public abstract class DisguiseManager implements Listener {
 	}
 	
 	public void removeDisguise(Player player, boolean sendPlayerPackets, boolean delaySpawnPacket) {
-		DisguiseSpell.Disguise disguise = disguises.remove(player.getName().toLowerCase());
+		DisguiseSpell.Disguise disguise = disguises.get(player.getName().toLowerCase());
 		disguisedEntityIds.remove(player.getEntityId());
 		dragons.remove(player.getEntityId());
 		if (disguise != null) {
 			clearDisguise(player, sendPlayerPackets, delaySpawnPacket);
 			disguise.getSpell().undisguise(player);
+			disguises.remove(player.getName().toLowerCase());
 		}
 		mounts.remove(player.getEntityId());
 	}

--- a/src/com/nisovin/magicspells/volatilecode/DisguiseManager_1_8_R1.java
+++ b/src/com/nisovin/magicspells/volatilecode/DisguiseManager_1_8_R1.java
@@ -564,6 +564,18 @@ public class DisguiseManager_1_8_R1 extends DisguiseManager {
 	
 	@Override
 	protected void sendDestroyEntityPackets(Player disguised, int entityId) {
+		DisguiseSpell.Disguise disguise = getDisguise(disguised);
+		if (disguise != null && disguise.getEntityType() == EntityType.PLAYER) {
+			Entity entity = getEntity(disguised, disguise);
+			if (Bukkit.getPlayer(entity.getUniqueID()) == null) {
+				PacketPlayOutPlayerInfo packetinfo = new PacketPlayOutPlayerInfo();
+				refPacketPlayerInfo.set(packetinfo, "a", EnumPlayerInfoAction.REMOVE_PLAYER);
+				List<PlayerInfoData> list = new ArrayList<PlayerInfoData>();
+				list.add(new PlayerInfoData(packetinfo, ((EntityHuman)entity).getProfile(), 0, EnumGamemode.SURVIVAL, new ChatComponentText(((EntityHuman)entity).getName())));
+				refPacketPlayerInfo.set(packetinfo, "b", list);
+				broadcastPacket(disguised, PacketType.Play.Server.PLAYER_INFO, packetinfo);
+			}
+		}
 		PacketPlayOutEntityDestroy packet29 = new PacketPlayOutEntityDestroy(entityId);
 		final EntityTracker tracker = ((CraftWorld)disguised.getWorld()).getHandle().tracker;
 		tracker.a(((CraftPlayer)disguised).getHandle(), packet29);

--- a/src/com/nisovin/magicspells/volatilecode/DisguiseManager_1_8_R1.java
+++ b/src/com/nisovin/magicspells/volatilecode/DisguiseManager_1_8_R1.java
@@ -325,11 +325,11 @@ public class DisguiseManager_1_8_R1 extends DisguiseManager {
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(16, Byte.valueOf((byte)1));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 				Bukkit.getScheduler().scheduleSyncDelayedTask(MagicSpells.plugin, new Runnable() {
 					public void run() {
 						dw.watch(16, Byte.valueOf((byte)0));
-						broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+						broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 					}
 				}, 10);
 			} else if (entityType == EntityType.WITCH) {
@@ -337,11 +337,11 @@ public class DisguiseManager_1_8_R1 extends DisguiseManager {
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(21, Byte.valueOf((byte)1));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 				Bukkit.getScheduler().scheduleSyncDelayedTask(MagicSpells.plugin, new Runnable() {
 					public void run() {
 						dw.watch(21, Byte.valueOf((byte)0));
-						broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+						broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 					}
 				}, 10);
 			/*} else if (entityType == EntityType.CREEPER && !disguise.getFlag()) {
@@ -349,11 +349,11 @@ public class DisguiseManager_1_8_R1 extends DisguiseManager {
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(17, Byte.valueOf((byte)1));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 				Bukkit.getScheduler().scheduleSyncDelayedTask(MagicSpells.plugin, new Runnable() {
 					public void run() {
 						dw.watch(17, Byte.valueOf((byte)0));
-						broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+						broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 					}
 				}, 10);*/
 			} else if (entityType == EntityType.WOLF) {
@@ -361,11 +361,11 @@ public class DisguiseManager_1_8_R1 extends DisguiseManager {
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(16, Byte.valueOf((byte)(p.isSneaking() ? 3 : 2)));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 				Bukkit.getScheduler().scheduleSyncDelayedTask(MagicSpells.plugin, new Runnable() {
 					public void run() {
 						dw.watch(16, Byte.valueOf((byte)(p.isSneaking() ? 1 : 0)));
-						broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+						broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 					}
 				}, 10);
 			} else if (entityType == EntityType.SLIME || entityType == EntityType.MAGMA_CUBE) {
@@ -373,11 +373,11 @@ public class DisguiseManager_1_8_R1 extends DisguiseManager {
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(16, Byte.valueOf((byte)(p.isSneaking() ? 2 : 3)));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 				Bukkit.getScheduler().scheduleSyncDelayedTask(MagicSpells.plugin, new Runnable() {
 					public void run() {
 						dw.watch(16, Byte.valueOf((byte)(p.isSneaking() ? 1 : 2)));
-						broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+						broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 					}
 				}, 10);
 			}
@@ -398,13 +398,13 @@ public class DisguiseManager_1_8_R1 extends DisguiseManager {
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(16, Byte.valueOf((byte)1));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 			} else {
 				final DataWatcher dw = new DataWatcher(entityPlayer);
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(16, Byte.valueOf((byte)0));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 			}
 		} else if (entityType == EntityType.ENDERMAN) {
 			if (event.isSneaking()) {
@@ -412,13 +412,13 @@ public class DisguiseManager_1_8_R1 extends DisguiseManager {
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(18, Byte.valueOf((byte)1));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 			} else {
 				final DataWatcher dw = new DataWatcher(entityPlayer);
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(18, Byte.valueOf((byte)0));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 			}
 		} else if (entityType == EntityType.SLIME || entityType == EntityType.MAGMA_CUBE) {
 			if (event.isSneaking()) {
@@ -426,13 +426,13 @@ public class DisguiseManager_1_8_R1 extends DisguiseManager {
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(16, Byte.valueOf((byte)1));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 			} else {
 				final DataWatcher dw = new DataWatcher(entityPlayer);
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(16, Byte.valueOf((byte)2));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 			}
 		} else if (entityType == EntityType.SHEEP && event.isSneaking()) {
 			p.playEffect(EntityEffect.SHEEP_EAT);
@@ -573,7 +573,7 @@ public class DisguiseManager_1_8_R1 extends DisguiseManager {
 				List<PlayerInfoData> list = new ArrayList<PlayerInfoData>();
 				list.add(new PlayerInfoData(packetinfo, ((EntityHuman)entity).getProfile(), 0, EnumGamemode.SURVIVAL, new ChatComponentText(((EntityHuman)entity).getName())));
 				refPacketPlayerInfo.set(packetinfo, "b", list);
-				broadcastPacket(disguised, PacketType.Play.Server.PLAYER_INFO, packetinfo);
+				broadcastPacketGlobal(PacketType.Play.Server.PLAYER_INFO, packetinfo);
 			}
 		}
 		PacketPlayOutEntityDestroy packet29 = new PacketPlayOutEntityDestroy(entityId);
@@ -581,9 +581,22 @@ public class DisguiseManager_1_8_R1 extends DisguiseManager {
 		tracker.a(((CraftPlayer)disguised).getHandle(), packet29);
 	}
 	
-	private void broadcastPacket(Player disguised, PacketType packetId, Packet packet) {
+	private void broadcastPacketDisguised(Player disguised, PacketType packetId, Packet packet) {
 		PacketContainer con = new PacketContainer(packetId, packet);
 		for (Player player : protocolManager.getEntityTrackers(disguised)) {
+			if (player.isValid()) {
+				try {
+					protocolManager.sendServerPacket(player, con, false);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+		}
+	}
+
+	private void broadcastPacketGlobal(PacketType packetId, Packet packet) {
+		PacketContainer con = new PacketContainer(packetId, packet);
+		for (Player player : Bukkit.getOnlinePlayers()) {
 			if (player.isValid()) {
 				try {
 					protocolManager.sendServerPacket(player, con, false);
@@ -628,13 +641,13 @@ public class DisguiseManager_1_8_R1 extends DisguiseManager {
 				final EntityTracker tracker = ((CraftWorld)disguised.getWorld()).getHandle().tracker;
 				for (Packet packet : packets) {
 					if (packet instanceof PacketPlayOutEntityMetadata) {
-						broadcastPacket(disguised, PacketType.Play.Server.ENTITY_METADATA, packet);
+						broadcastPacketDisguised(disguised, PacketType.Play.Server.ENTITY_METADATA, packet);
 					} else if (packet instanceof PacketPlayOutNamedEntitySpawn) {
-						broadcastPacket(disguised, PacketType.Play.Server.NAMED_ENTITY_SPAWN, packet);
+						broadcastPacketDisguised(disguised, PacketType.Play.Server.NAMED_ENTITY_SPAWN, packet);
 					} else if (packet instanceof PacketPlayOutPlayerInfo) {
-						broadcastPacket(disguised, PacketType.Play.Server.PLAYER_INFO, packet);
+						broadcastPacketGlobal(PacketType.Play.Server.PLAYER_INFO, packet);
 					} else if (packet instanceof PacketPlayOutSpawnEntityLiving) {
-						broadcastPacket(disguised, PacketType.Play.Server.SPAWN_ENTITY_LIVING, packet);
+						broadcastPacketDisguised(disguised, PacketType.Play.Server.SPAWN_ENTITY_LIVING, packet);
 					} else {
 						tracker.a(((CraftPlayer)disguised).getHandle(), packet);
 					}

--- a/src/com/nisovin/magicspells/volatilecode/DisguiseManager_1_8_R1.java
+++ b/src/com/nisovin/magicspells/volatilecode/DisguiseManager_1_8_R1.java
@@ -78,9 +78,6 @@ public class DisguiseManager_1_8_R1 extends DisguiseManager {
 				}
 			} catch (Exception e) {
 			}
-			if (uuid == null) {
-				uuid = UUID.randomUUID();
-			}
 			
 			GameProfile profile = new GameProfile(uuid, name);
 			

--- a/src/com/nisovin/magicspells/volatilecode/DisguiseManager_1_8_R3.java
+++ b/src/com/nisovin/magicspells/volatilecode/DisguiseManager_1_8_R3.java
@@ -567,6 +567,18 @@ public class DisguiseManager_1_8_R3 extends DisguiseManager {
 	
 	@Override
 	protected void sendDestroyEntityPackets(Player disguised, int entityId) {
+		DisguiseSpell.Disguise disguise = getDisguise(disguised);
+		if (disguise != null && disguise.getEntityType() == EntityType.PLAYER) {
+			Entity entity = getEntity(disguised, disguise);
+			if (Bukkit.getPlayer(entity.getUniqueID()) == null) {
+				PacketPlayOutPlayerInfo packetinfo = new PacketPlayOutPlayerInfo();
+				refPacketPlayerInfo.set(packetinfo, "a", EnumPlayerInfoAction.REMOVE_PLAYER);
+				List<PlayerInfoData> list = new ArrayList<PlayerInfoData>();
+				list.add(packetinfo.new PlayerInfoData(((EntityHuman)entity).getProfile(), 0, EnumGamemode.SURVIVAL, new ChatComponentText(((EntityHuman)entity).getName())));
+				refPacketPlayerInfo.set(packetinfo, "b", list);
+				broadcastPacket(disguised, PacketType.Play.Server.PLAYER_INFO, packetinfo);
+			}
+		}
 		PacketPlayOutEntityDestroy packet29 = new PacketPlayOutEntityDestroy(entityId);
 		final EntityTracker tracker = ((CraftWorld)disguised.getWorld()).getHandle().tracker;
 		tracker.a(((CraftPlayer)disguised).getHandle(), packet29);

--- a/src/com/nisovin/magicspells/volatilecode/DisguiseManager_1_8_R3.java
+++ b/src/com/nisovin/magicspells/volatilecode/DisguiseManager_1_8_R3.java
@@ -328,11 +328,11 @@ public class DisguiseManager_1_8_R3 extends DisguiseManager {
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(16, Byte.valueOf((byte)1));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 				Bukkit.getScheduler().scheduleSyncDelayedTask(MagicSpells.plugin, new Runnable() {
 					public void run() {
 						dw.watch(16, Byte.valueOf((byte)0));
-						broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+						broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 					}
 				}, 10);
 			} else if (entityType == EntityType.WITCH) {
@@ -340,11 +340,11 @@ public class DisguiseManager_1_8_R3 extends DisguiseManager {
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(21, Byte.valueOf((byte)1));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 				Bukkit.getScheduler().scheduleSyncDelayedTask(MagicSpells.plugin, new Runnable() {
 					public void run() {
 						dw.watch(21, Byte.valueOf((byte)0));
-						broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+						broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 					}
 				}, 10);
 			/*} else if (entityType == EntityType.CREEPER && !disguise.getFlag()) {
@@ -352,11 +352,11 @@ public class DisguiseManager_1_8_R3 extends DisguiseManager {
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(17, Byte.valueOf((byte)1));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 				Bukkit.getScheduler().scheduleSyncDelayedTask(MagicSpells.plugin, new Runnable() {
 					public void run() {
 						dw.watch(17, Byte.valueOf((byte)0));
-						broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+						broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 					}
 				}, 10);*/
 			} else if (entityType == EntityType.WOLF) {
@@ -364,11 +364,11 @@ public class DisguiseManager_1_8_R3 extends DisguiseManager {
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(16, Byte.valueOf((byte)(p.isSneaking() ? 3 : 2)));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 				Bukkit.getScheduler().scheduleSyncDelayedTask(MagicSpells.plugin, new Runnable() {
 					public void run() {
 						dw.watch(16, Byte.valueOf((byte)(p.isSneaking() ? 1 : 0)));
-						broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+						broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 					}
 				}, 10);
 			} else if (entityType == EntityType.SLIME || entityType == EntityType.MAGMA_CUBE) {
@@ -376,11 +376,11 @@ public class DisguiseManager_1_8_R3 extends DisguiseManager {
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(16, Byte.valueOf((byte)(p.isSneaking() ? 2 : 3)));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 				Bukkit.getScheduler().scheduleSyncDelayedTask(MagicSpells.plugin, new Runnable() {
 					public void run() {
 						dw.watch(16, Byte.valueOf((byte)(p.isSneaking() ? 1 : 2)));
-						broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+						broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 					}
 				}, 10);
 			}
@@ -401,13 +401,13 @@ public class DisguiseManager_1_8_R3 extends DisguiseManager {
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(16, Byte.valueOf((byte)1));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 			} else {
 				final DataWatcher dw = new DataWatcher(entityPlayer);
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(16, Byte.valueOf((byte)0));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 			}
 		} else if (entityType == EntityType.ENDERMAN) {
 			if (event.isSneaking()) {
@@ -415,13 +415,13 @@ public class DisguiseManager_1_8_R3 extends DisguiseManager {
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(18, Byte.valueOf((byte)1));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 			} else {
 				final DataWatcher dw = new DataWatcher(entityPlayer);
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(18, Byte.valueOf((byte)0));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 			}
 		} else if (entityType == EntityType.SLIME || entityType == EntityType.MAGMA_CUBE) {
 			if (event.isSneaking()) {
@@ -429,13 +429,13 @@ public class DisguiseManager_1_8_R3 extends DisguiseManager {
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(16, Byte.valueOf((byte)1));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 			} else {
 				final DataWatcher dw = new DataWatcher(entityPlayer);
 				dw.a(0, Byte.valueOf((byte) 0));
 				dw.a(1, Short.valueOf((short) 300));
 				dw.a(16, Byte.valueOf((byte)2));
-				broadcastPacket(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
+				broadcastPacketDisguised(p, PacketType.Play.Server.ENTITY_METADATA, new PacketPlayOutEntityMetadata(entityId, dw, true));
 			}
 		} else if (entityType == EntityType.SHEEP && event.isSneaking()) {
 			p.playEffect(EntityEffect.SHEEP_EAT);
@@ -576,7 +576,7 @@ public class DisguiseManager_1_8_R3 extends DisguiseManager {
 				List<PlayerInfoData> list = new ArrayList<PlayerInfoData>();
 				list.add(packetinfo.new PlayerInfoData(((EntityHuman)entity).getProfile(), 0, EnumGamemode.SURVIVAL, new ChatComponentText(((EntityHuman)entity).getName())));
 				refPacketPlayerInfo.set(packetinfo, "b", list);
-				broadcastPacket(disguised, PacketType.Play.Server.PLAYER_INFO, packetinfo);
+				broadcastPacketGlobal(PacketType.Play.Server.PLAYER_INFO, packetinfo);
 			}
 		}
 		PacketPlayOutEntityDestroy packet29 = new PacketPlayOutEntityDestroy(entityId);
@@ -584,9 +584,22 @@ public class DisguiseManager_1_8_R3 extends DisguiseManager {
 		tracker.a(((CraftPlayer)disguised).getHandle(), packet29);
 	}
 	
-	private void broadcastPacket(Player disguised, PacketType packetId, Packet packet) {
+	private void broadcastPacketDisguised(Player disguised, PacketType packetId, Packet packet) {
 		PacketContainer con = new PacketContainer(packetId, packet);
 		for (Player player : protocolManager.getEntityTrackers(disguised)) {
+			if (player.isValid()) {
+				try {
+					protocolManager.sendServerPacket(player, con, false);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+		}
+	}
+	
+	private void broadcastPacketGlobal(PacketType packetId, Packet packet) {
+		PacketContainer con = new PacketContainer(packetId, packet);
+		for (Player player : Bukkit.getOnlinePlayers()) {
 			if (player.isValid()) {
 				try {
 					protocolManager.sendServerPacket(player, con, false);
@@ -631,13 +644,13 @@ public class DisguiseManager_1_8_R3 extends DisguiseManager {
 				final EntityTracker tracker = ((CraftWorld)disguised.getWorld()).getHandle().tracker;
 				for (Packet packet : packets) {
 					if (packet instanceof PacketPlayOutEntityMetadata) {
-						broadcastPacket(disguised, PacketType.Play.Server.ENTITY_METADATA, packet);
+						broadcastPacketDisguised(disguised, PacketType.Play.Server.ENTITY_METADATA, packet);
 					} else if (packet instanceof PacketPlayOutNamedEntitySpawn) {
-						broadcastPacket(disguised, PacketType.Play.Server.NAMED_ENTITY_SPAWN, packet);
+						broadcastPacketDisguised(disguised, PacketType.Play.Server.NAMED_ENTITY_SPAWN, packet);
 					} else if (packet instanceof PacketPlayOutPlayerInfo) {
-						broadcastPacket(disguised, PacketType.Play.Server.PLAYER_INFO, packet);
+						broadcastPacketGlobal(PacketType.Play.Server.PLAYER_INFO, packet);
 					} else if (packet instanceof PacketPlayOutSpawnEntityLiving) {
-						broadcastPacket(disguised, PacketType.Play.Server.SPAWN_ENTITY_LIVING, packet);
+						broadcastPacketDisguised(disguised, PacketType.Play.Server.SPAWN_ENTITY_LIVING, packet);
 					} else {
 						tracker.a(((CraftPlayer)disguised).getHandle(), packet);
 					}

--- a/src/com/nisovin/magicspells/volatilecode/DisguiseManager_1_8_R3.java
+++ b/src/com/nisovin/magicspells/volatilecode/DisguiseManager_1_8_R3.java
@@ -81,9 +81,6 @@ public class DisguiseManager_1_8_R3 extends DisguiseManager {
 				}
 			} catch (Exception e) {
 			}
-			if (uuid == null) {
-				uuid = UUID.randomUUID();
-			}
 			
 			GameProfile profile = new GameProfile(uuid, name);
 			


### PR DESCRIPTION
Properly handles displaying player disguises in the (tab) player list. Currently, disguises can show up in the list multiple times.  

![Duplicate disguise example](http://i.imgur.com/JCH83UN.png)  

Reason for this is that players are not removed from the player list when undisguised, and random UUIDs get calculated every time a disguise loads. This causes the re-render of of the disguise not to override the old entry in the player list.  

This pull requests fixes this issue by removing players from the tab list when the disguise is not loaded, as well as calculating a random UUID only once per disguise instance. This means a disguise will only show up (once) in the player list if there is an online player that has that disguise.