### PR TITLE
Packet condition fix

### DIFF
--- a/src/com/nisovin/magicspells/volatilecode/DisguiseManager_1_8_R1.java
+++ b/src/com/nisovin/magicspells/volatilecode/DisguiseManager_1_8_R1.java
@@ -597,12 +597,10 @@ public class DisguiseManager_1_8_R1 extends DisguiseManager {
 	private void broadcastPacketGlobal(PacketType packetId, Packet packet) {
 		PacketContainer con = new PacketContainer(packetId, packet);
 		for (Player player : Bukkit.getOnlinePlayers()) {
-			if (player.isValid()) {
-				try {
-					protocolManager.sendServerPacket(player, con, false);
-				} catch (Exception e) {
-					e.printStackTrace();
-				}
+			try {
+				protocolManager.sendServerPacket(player, con, false);
+			} catch (Exception e) {
+				e.printStackTrace();
 			}
 		}
 	}

--- a/src/com/nisovin/magicspells/volatilecode/DisguiseManager_1_8_R3.java
+++ b/src/com/nisovin/magicspells/volatilecode/DisguiseManager_1_8_R3.java
@@ -600,12 +600,10 @@ public class DisguiseManager_1_8_R3 extends DisguiseManager {
 	private void broadcastPacketGlobal(PacketType packetId, Packet packet) {
 		PacketContainer con = new PacketContainer(packetId, packet);
 		for (Player player : Bukkit.getOnlinePlayers()) {
-			if (player.isValid()) {
-				try {
-					protocolManager.sendServerPacket(player, con, false);
-				} catch (Exception e) {
-					e.printStackTrace();
-				}
+			try {
+				protocolManager.sendServerPacket(player, con, false);
+			} catch (Exception e) {
+				e.printStackTrace();
 			}
 		}
 	}


### PR DESCRIPTION
Removes a flawed condition to check whether a `PlayerInfoPacket` will be sent.  

The condition blocks the packet being sent when the receiver dies and does not respawn before the server attempts to send the packet. This can cause a player disguise not being removed from the player list for players in their death screen. Since this packet does not actually create an entity (it only loads a player's profile, gamemode and name), it can be sent while a player has despawned.