### PR TITLE
Add config option to use disguise target uuid

### DIFF
--- a/src/com/nisovin/magicspells/spells/targeted/DisguiseSpell.java
+++ b/src/com/nisovin/magicspells/spells/targeted/DisguiseSpell.java
@@ -342,7 +342,15 @@ public class DisguiseSpell extends TargetedSpell implements TargetedEntitySpell 
 	private void disguise(Player player) {
 		String nameplate = nameplateText;
 		if (showPlayerName) nameplate = player.getDisplayName();
-		PlayerDisguiseData playerDisguiseData = new PlayerDisguiseData((uuid.isEmpty() ? UUID.randomUUID().toString() : uuid), skin, skinSig);
+		String uuid;
+		if (this.uuid.isEmpty()) {
+			uuid = UUID.randomUUID().toString();
+		} else if (this.uuid.equalsIgnoreCase("target")) {
+			uuid = player.getUniqueId().toString();
+		} else {
+			uuid = this.uuid;
+		}
+		PlayerDisguiseData playerDisguiseData = new PlayerDisguiseData(uuid, skin, skinSig);
 		Disguise disguise = new Disguise(player, entityType, nameplate, playerDisguiseData, alwaysShowNameplate, disguiseSelf, ridingBoat, flag, var1, var2, var3, duration, this);
 		manager.addDisguise(player, disguise);
 		disguised.put(player.getName().toLowerCase(), disguise);


### PR DESCRIPTION
Adds an option to the disguise spell to use the uuid of the spell target.

This can be useful to go "incognito", since it will override the disguised player's entry in the tab list, making it so other players cannot see the player who is disguised in there.